### PR TITLE
retain formatting option when creating 1st post of discussion

### DIFF
--- a/src/Services/DiscussionService.php
+++ b/src/Services/DiscussionService.php
@@ -33,7 +33,7 @@ class DiscussionService
 
         // Make the post and attach it to the user
         $post = $user->posts()->make(
-            $this->getSanitizedPostData($request->only('content'))
+            $this->getSanitizedPostData($request->only(['formatting', 'content']))
         );
 
         $discussion->posts()->save($post);


### PR DESCRIPTION
When creating a discussion, the formatting option (rich/plain) is not used