### PR TITLE
Make watchers' email subject translatable

### DIFF
--- a/src/Mail/PostAddedEmail.php
+++ b/src/Mail/PostAddedEmail.php
@@ -31,7 +31,7 @@ class PostAddedEmail extends Mailable
     public function build()
     {
         return $this
-            ->subject('New Post Added to Discussion "'.$this->post->discussion->title.'"')
+            ->subject(__('New post added to discussion') . ' "'.$this->post->discussion->title.'"' )
             ->markdown('firefly::mail.new-post');
     }
 }


### PR DESCRIPTION
The subject of emails was not translatable